### PR TITLE
Validate search string to prevent empty results

### DIFF
--- a/app/controllers/manager/deck_manager.rb
+++ b/app/controllers/manager/deck_manager.rb
@@ -596,7 +596,11 @@ class DeckManager < NSWindowController
   def search(sender)
     str = sender.stringValue
 
-    search_card(str)
+    if str and !str.empty?
+      search_card(str)
+    else
+      cancel_search(sender)
+    end
   end
 
   def search_card(str)


### PR DESCRIPTION
Validate search string to prevent empty results. Similar to line 200 in c12921b5edbfb6b5fae2c8c90a9a247e1b4ca850

Without this, the user will see empty results if he uses backspace to clear the search field.