### PR TITLE
Improve UI feedback during Hearthstats login

### DIFF
--- a/HSTracker/Hearthstats/Base.lproj/HearthstatsLogin.xib
+++ b/HSTracker/Hearthstats/Base.lproj/HearthstatsLogin.xib
@@ -1,13 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="15E65" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10116"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="HearthstatsLogin" customModule="HSTracker" customModuleProvider="target">
             <connections>
+                <outlet property="cancelButton" destination="BuD-jL-AQY" id="dRa-Du-uCW"/>
                 <outlet property="email" destination="rCi-rB-vcu" id="6ot-Ju-dk4"/>
+                <outlet property="loginButton" destination="hK8-6A-gSq" id="ae9-AN-3BA"/>
                 <outlet property="password" destination="TAe-tk-Aud" id="Yqv-Wm-qiX"/>
+                <outlet property="progressIndicator" destination="ahA-du-Ndb" id="wvn-hu-i2I"/>
                 <outlet property="window" destination="QvC-M9-y7g" id="iMu-gw-U4H"/>
             </connections>
         </customObject>
@@ -70,6 +73,9 @@
                         <buttonCell key="cell" type="push" title="Login" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="DxZ-Do-AVD">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
+                            <string key="keyEquivalent" base64-UTF8="YES">
+DQ
+</string>
                         </buttonCell>
                         <connections>
                             <action selector="connect:" target="-2" id="j5P-be-gjm"/>
@@ -88,6 +94,9 @@ Gw
                             <action selector="cancel:" target="-2" id="XWd-av-czT"/>
                         </connections>
                     </button>
+                    <progressIndicator hidden="YES" wantsLayer="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" maxValue="100" bezeled="NO" indeterminate="YES" controlSize="small" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="ahA-du-Ndb">
+                        <rect key="frame" x="243" y="22" width="16" height="16"/>
+                    </progressIndicator>
                 </subviews>
                 <constraints>
                     <constraint firstItem="rCi-rB-vcu" firstAttribute="leading" secondItem="5eW-i3-itH" secondAttribute="leading" id="0xd-hQ-BT3"/>

--- a/HSTracker/Hearthstats/HearthstatsLogin.swift
+++ b/HSTracker/Hearthstats/HearthstatsLogin.swift
@@ -12,38 +12,78 @@ class HearthstatsLogin: NSWindowController {
 
     @IBOutlet weak var email: NSTextField!
     @IBOutlet weak var password: NSSecureTextField!
+    @IBOutlet weak var progressIndicator: NSProgressIndicator!
+    @IBOutlet weak var cancelButton: NSButton!
+    @IBOutlet weak var loginButton: NSButton!
 
     @IBAction func cancel(sender: AnyObject) {
         self.window?.sheetParent?.endSheet(self.window!, returnCode: NSModalResponseOK)
     }
 
     @IBAction func connect(sender: AnyObject) {
+        configureUserInterfaceForNetworkActivity(true)
+
         HearthstatsAPI.login(email.stringValue, password.stringValue) { (success, message) in
-
-            let alert = NSAlert()
             if success {
-                alert.alertStyle = .InformationalAlertStyle
-                alert.messageText = NSLocalizedString("You are now connected to Hearthstats",
-                                                      comment: "")
-            } else {
-                alert.alertStyle = .CriticalAlertStyle
-                alert.messageText = message
-            }
-
-            alert.beginSheetModalForWindow(self.window!, completionHandler: { (response) in
-                if success {
-                    do {
-                        try HearthstatsAPI.loadDecks(true) { (success, newDecks) in
-                            self.window?.sheetParent?.endSheet(self.window!,
-                                returnCode: NSModalResponseOK)
-                        }
-                    } catch HearthstatsError.NotLogged {
-                        print("not logged")
-                    } catch {
-                        print("??? logged")
+                self.loadDecks() { (success) -> (Void) in
+                    let message = NSLocalizedString("You are now connected to Hearthstats",
+                                                    comment: "")
+                    self.displayAlert(.InformationalAlertStyle, message: message) {
+                        self.endSheet()
                     }
                 }
-            })
+            } else {
+                self.displayAlert(.CriticalAlertStyle, message: message) {
+                    self.configureUserInterfaceForNetworkActivity(false)
+                    self.email.becomeFirstResponder()
+                }
+            }
         }
+    }
+
+    private func configureUserInterfaceForNetworkActivity(isNetworkActivityInProgress: Bool) {
+        if isNetworkActivityInProgress {
+            self.window?.makeFirstResponder(nil)
+            progressIndicator.hidden = false
+            progressIndicator.startAnimation(self)
+        } else {
+            progressIndicator.hidden = true
+            self.window?.makeFirstResponder(email)
+            progressIndicator.stopAnimation(self)
+        }
+
+        [ email, password ].forEach {
+            $0.selectable = !isNetworkActivityInProgress
+            $0.editable = !isNetworkActivityInProgress
+        }
+        [ loginButton, cancelButton ].forEach { $0.enabled = !isNetworkActivityInProgress }
+    }
+
+    private func displayAlert(style: NSAlertStyle, message: String, completion: (Void) -> (Void)) {
+        let alert = NSAlert()
+        alert.alertStyle = style
+        alert.messageText = message
+
+        alert.beginSheetModalForWindow(self.window!) { (response) in
+            completion()
+        }
+    }
+
+    private func loadDecks(completion: (Bool) -> (Void)) {
+        do {
+            try HearthstatsAPI.loadDecks(true) { (success, newDecks) in
+                completion(success)
+            }
+        } catch HearthstatsError.NotLogged {
+            print("not logged")
+            completion(false)
+        } catch {
+            print("??? logged")
+            completion(false)
+        }
+    }
+
+    private func endSheet() {
+        window?.sheetParent?.endSheet(self.window!, returnCode: NSModalResponseOK)
     }
 }


### PR DESCRIPTION
Improves the UI feedback while logging into Hearthstats from within the
app:

* While authentication is in-flight, disable the login form and show a
  progress indicator.
* Make the “Login” button the default button so hitting enter will start
  authentication.
* After successful authentication, let the `loadDecks` call complete
  before showing the “login succeeded” alert. Previously, the user would
  see the “login succeeded” alert, but after dismissing it, the login
  screen would remain visible for a few seconds while `loadDecks`
  completed, but it was unclear to the user that anything was happening.
  This cleans up that interaction to prevent the user from interacting
  with the UI until everything has completed.