### PR TITLE
Deck Manager (editor) - keyboard shortcuts for adding a card to the deck

### DIFF
--- a/HSTracker/UIs/DeckManager/EditDeck.swift
+++ b/HSTracker/UIs/DeckManager/EditDeck.swift
@@ -109,37 +109,60 @@ class EditDeck: NSWindowController, NSComboBoxDataSource, NSComboBoxDelegate {
 
         NSEvent.addLocalMonitorForEventsMatchingMask(.KeyDownMask) { (e) -> NSEvent? in
             let isCmd = e.modifierFlags.contains(.CommandKeyMask)
-            // let isShift = e.modifierFlags.contains(.ShiftKeyMask)
 
-            guard isCmd else { return e }
+            if isCmd {
+                switch e.keyCode {
+                case 6:
+                    self.window!.performClose(nil)
+                    return nil
 
-            switch e.keyCode {
-            case 6:
-                self.window!.performClose(nil)
-                return nil
+                case 3: // cmd-f
+                    self.searchField.selectText(self)
+                    self.searchField.becomeFirstResponder()
+                    return nil
 
-            case 3: // cmd-f
-                self.searchField.selectText(self)
-                self.searchField.becomeFirstResponder()
-                return nil
+                case 1: // cmd-s
+                    self.save(nil)
+                    return nil
 
-            case 1: // cmd-s
-                self.save(nil)
-                return nil
-
-            case 12: // cmd-a
-                // swiftlint:disable line_length
-                if let selected = self.cardsCollectionView.indexPathsForSelectedItems() as? [NSIndexPath],
+                case 12: // cmd-a
+                    // swiftlint:disable line_length
+                    if let selected = self.cardsCollectionView.indexPathsForSelectedItems() as? [NSIndexPath],
                     cell: CardCell = self.cardsCollectionView.cellForItemAtIndexPath(selected.first) as? CardCell,
                     card = cell.card {
                         self.addCardToDeck(card)
-                }
-                // swiftlint:enable line_length
+                    }
+                    // swiftlint:enable line_length
 
-            default:
+                default:
+                    break
+                }
+
+                // cmd-[1 to 9] for adding a card to a deck.
+                //
+                // Using characters pressed rather than keycodes, as keycodes
+                // distinguish between numpads and numbers above qwerty etc..
+                //
+                guard let charsPressed = e.charactersIgnoringModifiers,
+                          numberPressed = Int(charsPressed.charAt(0)),
+                          visibleCardIndexPaths = self.cardsCollectionView
+                                                      .indexPathsForVisibleItems()
+                                                  as? [NSIndexPath]
+                    where 1 ... visibleCardIndexPaths.count ~= numberPressed
+                    else { return e }
+
+                if let cell = self.cardsCollectionView
+                                  .cellForItemAtIndexPath(visibleCardIndexPaths[numberPressed - 1])
+                              as? CardCell,
+                       card = cell.card {
+
+                    self.addCardToDeck(card)
+                    return nil
+                }
+                
                 Log.verbose?.message("unsupported keycode \(e.keyCode)")
-                break
             }
+
             return e
         }
         NSNotificationCenter.defaultCenter()


### PR DESCRIPTION
**Motivation:**
Often building arena decks, and my workflow is currently:
 1. press ⌘+F
 2. type first few chars of the card until there are only few cards (ideally just one) on the screen so that it is easily spotted in the few
 3. click on the card
 4. goto step 1.

The switch between keyboard for filtering cards and mouse for selecting one of the few cards left after filtering is annoying me :D
<hr>
**Solution:**
Implemented keyboard shortcuts ⌘-[1 to 9], where the number is the position of the first 9 cards in the grid view (counting from left to right including wrapping around). This allows for the following flow:
 1. press ⌘+F
 2. type first few chars of the card until there are only few cards (ideally just one) on the screen so that it is easily spotted in the few
 3. seeing the card I desire is now the 3rd card listed, press ⌘+3
 4. goto step 1.

Sometimes even the first few chars of a card's name are unique enough to only show one card, in which case this is still a time saver as the ⌘+1 adds that one (understandably) :)

Implementation relies on "characters pressed" rather than "keycodes pressed", which should cover both numbers on the numpad and above the numbers above the letters on the keyboard. 

**Needs testing on a numpad**, I don't have a full-sized keyboard around, tenkeyless for life! :D
<hr>
**Other comments**:
Diff in github looks a bit shite since I moved around one whole block of original code to make logic for introducing my set of commands simpler. Fear not!

Also beware, this is my first time seeing/coding Swift :)
