### PR TITLE
Show the name of the deck when you're editing it

### DIFF
--- a/HSTracker/UIs/DeckManager/EditDeck.swift
+++ b/HSTracker/UIs/DeckManager/EditDeck.swift
@@ -99,6 +99,10 @@ class EditDeck: NSWindowController, NSComboBoxDataSource, NSComboBoxDelegate {
         loadCardTypes()
         loadRarities()
         loadRaces()
+        
+        if let name = self.currentDeck?.name {
+            self.window?.title = name
+        }
 
         zoom.doubleValue = settings.deckManagerZoom
 


### PR DESCRIPTION
I'm not sure if this was designed like this, but if you're editing multiple decks (possibly of the same class), it's not completely easy to figure out what deck you're editing.

Showing the name of the deck seems like a really easy fix