### PR TITLE
Fix syntax errors in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
   - brew update
   - brew install carthage || brew upgrade carthage
   - brew outdated xctool || brew upgrade xctool
-  - carthage update --platform Mac
+  - carthage bootstrap --platform Mac
 script:
   - travis_wait 35 xctool -project HSTracker.xcodeproj -scheme HSTracker -sdk macosx clean build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
   - travis_wait 35 xctool -project HSTracker.xcodeproj -scheme HSTracker -sdk macosx test CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
   - brew update
   - brew install carthage || brew upgrade carthage
   - brew outdated xctool || brew upgrade xctool
-  - travis_wait 35 carthage update --platform OSX
+  - carthage update --platform Mac
 script:
   - travis_wait 35 xctool -project HSTracker.xcodeproj -scheme HSTracker -sdk macosx clean build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
   - travis_wait 35 xctool -project HSTracker.xcodeproj -scheme HSTracker -sdk macosx test CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,5 @@ before_install:
   - brew outdated xctool || brew upgrade xctool
   - travis_wait 35 carthage update --platform OSX
 script:
-  - travis_wait 35 xctool -project HSTracker.xcodeproj -scheme HSTracker -sdk macosx clean build CODE_SIGN_IDENTITY=""
-  - CODE_SIGNING_REQUIRED=NO
-  - travis_wait 35 xctool -project HSTracker.xcodeproj -scheme HSTracker -sdk macosx test CODE_SIGN_IDENTITY=""
-  - CODE_SIGNING_REQUIRED=NO
+  - travis_wait 35 xctool -project HSTracker.xcodeproj -scheme HSTracker -sdk macosx clean build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+  - travis_wait 35 xctool -project HSTracker.xcodeproj -scheme HSTracker -sdk macosx test CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ before_install:
   - brew outdated xctool || brew upgrade xctool
   - carthage bootstrap --platform Mac
 script:
-  - travis_wait 35 xctool -project HSTracker.xcodeproj -scheme HSTracker -sdk macosx clean build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
-  - travis_wait 35 xctool -project HSTracker.xcodeproj -scheme HSTracker -sdk macosx test CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+  - xctool -project HSTracker.xcodeproj -scheme HSTracker -sdk macosx clean build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+  - xctool -project HSTracker.xcodeproj -scheme HSTracker -sdk macosx test CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ before_install:
   - brew update
   - brew install carthage || brew upgrade carthage
   - brew outdated xctool || brew upgrade xctool
+  - gem install xcpretty
   - carthage bootstrap --platform Mac
 script:
-  - xctool -project HSTracker.xcodeproj -scheme HSTracker -sdk macosx clean build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
-  - xctool -project HSTracker.xcodeproj -scheme HSTracker -sdk macosx test CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+  - xcodebuild -project HSTracker.xcodeproj -scheme HSTracker -sdk macosx clean build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty
+  - xcodebuild -project HSTracker.xcodeproj -scheme HSTracker -sdk macosx test CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ before_install:
   - brew install carthage || brew upgrade carthage
   - brew outdated xctool || brew upgrade xctool
   - travis_wait 35 carthage update --platform OSX
-script: 
+script:
   - travis_wait 35 xctool -project HSTracker.xcodeproj -scheme HSTracker -sdk macosx clean build CODE_SIGN_IDENTITY=""
-  CODE_SIGNING_REQUIRED=NO
+  - CODE_SIGNING_REQUIRED=NO
   - travis_wait 35 xctool -project HSTracker.xcodeproj -scheme HSTracker -sdk macosx test CODE_SIGN_IDENTITY=""
-  CODE_SIGNING_REQUIRED=NO
+  - CODE_SIGNING_REQUIRED=NO

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ osx_image: xcode7.3
 before_install:
   - brew update
   - brew install carthage || brew upgrade carthage
-  - brew outdated xctool || brew upgrade xctool
   - gem install xcpretty
   - carthage bootstrap --platform Mac
 script:
-  - xcodebuild -project HSTracker.xcodeproj -scheme HSTracker -sdk macosx clean build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty
-  - xcodebuild -project HSTracker.xcodeproj -scheme HSTracker -sdk macosx test CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty
+  - set -o pipefail && xcodebuild -project HSTracker.xcodeproj -scheme HSTracker -sdk macosx clean build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty
+  - set -o pipefail && xcodebuild -project HSTracker.xcodeproj -scheme HSTracker -sdk macosx test CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty


### PR DESCRIPTION
Fixed missing `-` in travis.yml file
Used http://lint.travis-ci.org/ to lint the travis file.
Test should now output something significant instead of
`ERROR: An error occured while trying to parse your .travis.yml file.`

P.S:
just out of curiosity, is there a reason why `CODE_SIGNING_REQUIRED=NO` is done twice?
