### PR TITLE
Ability to archive/unarchive deck

### DIFF
--- a/HSTracker/AppDelegate.swift
+++ b/HSTracker/AppDelegate.swift
@@ -598,7 +598,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
                                       action: nil,
                                       keyEquivalent: "") {
                 let classMenu = NSMenu()
-                _decks.sort({$0.name!.lowercaseString < $1.name!.lowercaseString }).forEach({
+                _decks.filter({ $0.isArchived != true }).sort({$0.name!.lowercaseString < $1.name!.lowercaseString }).forEach({
                     if let item = classMenu.addItemWithTitle($0.name!,
                         action: #selector(AppDelegate.playDeck(_:)),
                         keyEquivalent: "") {

--- a/HSTracker/AppDelegate.swift
+++ b/HSTracker/AppDelegate.swift
@@ -598,7 +598,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
                                       action: nil,
                                       keyEquivalent: "") {
                 let classMenu = NSMenu()
-                _decks.filter({ $0.isArchived != true }).sort({$0.name!.lowercaseString < $1.name!.lowercaseString }).forEach({
+                _decks.filter({ $0.isActive == true }).sort({$0.name!.lowercaseString < $1.name!.lowercaseString }).forEach({
                     if let item = classMenu.addItemWithTitle($0.name!,
                         action: #selector(AppDelegate.playDeck(_:)),
                         keyEquivalent: "") {

--- a/HSTracker/Database/Models/Deck.swift
+++ b/HSTracker/Database/Models/Deck.swift
@@ -25,7 +25,6 @@ final class Deck: Unboxable, WrapCustomizable, Hashable, CustomStringConvertible
     var hearthstatsVersionId: Int?
     var isActive: Bool = true
     var isArena: Bool = false
-    var isArchived: Bool?
     private var _cards = [Card]()
     private var cards: [Card]?
     var statistics = [Statistic]()
@@ -47,7 +46,6 @@ final class Deck: Unboxable, WrapCustomizable, Hashable, CustomStringConvertible
         self.hearthstatsVersionId = unboxer.unbox("hearthstatsVersionId")
         self.isActive = unboxer.unbox("isActive")
         self.isArena = unboxer.unbox("isArena")
-        self.isArchived = unboxer.unbox("isArchived")
 
         let tmpCards: [String: Int] = unboxer.unbox("cards")
         for (cardId, count) in tmpCards {

--- a/HSTracker/Database/Models/Deck.swift
+++ b/HSTracker/Database/Models/Deck.swift
@@ -25,6 +25,7 @@ final class Deck: Unboxable, WrapCustomizable, Hashable, CustomStringConvertible
     var hearthstatsVersionId: Int?
     var isActive: Bool = true
     var isArena: Bool = false
+    var isArchived: Bool?
     private var _cards = [Card]()
     private var cards: [Card]?
     var statistics = [Statistic]()
@@ -46,6 +47,7 @@ final class Deck: Unboxable, WrapCustomizable, Hashable, CustomStringConvertible
         self.hearthstatsVersionId = unboxer.unbox("hearthstatsVersionId")
         self.isActive = unboxer.unbox("isActive")
         self.isArena = unboxer.unbox("isArena")
+        self.isArchived = unboxer.unbox("isArchived")
 
         let tmpCards: [String: Int] = unboxer.unbox("cards")
         for (cardId, count) in tmpCards {

--- a/HSTracker/Database/Models/Decks.swift
+++ b/HSTracker/Database/Models/Decks.swift
@@ -52,6 +52,7 @@ final class Decks {
                     }
                 }
             } catch {
+                Log.error?.message("Error loading decks: \(error)")
             }
         }
     }

--- a/HSTracker/UIs/DeckManager/Base.lproj/DeckManager.xib
+++ b/HSTracker/UIs/DeckManager/Base.lproj/DeckManager.xib
@@ -7,6 +7,7 @@
         <customObject id="-2" userLabel="File's Owner" customClass="DeckManager" customModule="HSTracker" customModuleProvider="target">
             <connections>
                 <outlet property="archiveButton" destination="J1s-i7-Cn1" id="Etp-1s-KmK"/>
+                <outlet property="archiveToolBarItem" destination="Fe5-be-5CS" id="xAW-pf-TRk"/>
                 <outlet property="curveView" destination="gl3-d5-lam" id="KjY-HS-ImR"/>
                 <outlet property="deckListTable" destination="Znw-pX-Aav" id="6Yh-1v-5F5"/>
                 <outlet property="decksTable" destination="Pdd-Yb-1af" id="CWs-js-WpT"/>

--- a/HSTracker/UIs/DeckManager/Base.lproj/DeckManager.xib
+++ b/HSTracker/UIs/DeckManager/Base.lproj/DeckManager.xib
@@ -30,7 +30,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="932" height="615"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
             <value key="minFullScreenContentSize" type="size" width="850" height="600"/>
             <view key="contentView" id="EiT-Mj-1SZ">
                 <rect key="frame" x="0.0" y="0.0" width="932" height="615"/>
@@ -493,6 +493,11 @@
                             <action selector="twitter:" target="-2" id="MFr-PO-0OR"/>
                         </connections>
                     </toolbarItem>
+                    <toolbarItem implicitItemIdentifier="3A56AE7E-7F31-476E-8958-F697125F53ED" explicitItemIdentifier="archive" label="Archive" paletteLabel="Archive" tag="-1" image="archive" id="Fe5-be-5CS">
+                        <connections>
+                            <action selector="archiveDeck:" target="-2" id="ypI-Pe-P3H"/>
+                        </connections>
+                    </toolbarItem>
                 </allowedToolbarItems>
                 <defaultToolbarItems>
                     <toolbarItem reference="7FY-gv-qwP"/>
@@ -500,6 +505,7 @@
                     <toolbarItem reference="Qp2-0h-Sid"/>
                     <toolbarItem reference="cbH-rI-BvP"/>
                     <toolbarItem reference="aaa-LK-buD"/>
+                    <toolbarItem reference="Fe5-be-5CS"/>
                     <toolbarItem reference="I75-rt-at9"/>
                     <toolbarItem reference="Xxv-sY-tej"/>
                     <toolbarItem reference="d38-Pq-vZv"/>

--- a/HSTracker/UIs/DeckManager/DeckManager.swift
+++ b/HSTracker/UIs/DeckManager/DeckManager.swift
@@ -17,6 +17,7 @@ class DeckManager: NSWindowController {
     @IBOutlet weak var statsLabel: NSTextField!
     @IBOutlet weak var progressView: NSView!
     @IBOutlet weak var progressIndicator: NSProgressIndicator!
+    @IBOutlet weak var archiveToolBarItem: NSToolbarItem!
 
     @IBOutlet weak var druidButton: NSButton!
     @IBOutlet weak var hunterButton: NSButton!
@@ -159,6 +160,8 @@ class DeckManager: NSWindowController {
         }
         let clickedRow = sender!.clickedRow!
         currentDeck = filteredDecks()[clickedRow]
+        let labelName = (currentDeck?.isArchived ?? false) ? "Unarchive" : "Archive"
+        self.archiveToolBarItem.label = NSLocalizedString(labelName, comment: "")
         deckListTable.reloadData()
         curveView.deck = currentDeck
         updateStatsLabel()
@@ -310,13 +313,18 @@ class DeckManager: NSWindowController {
         if let deck = currentDeck {
             let alert = NSAlert()
             alert.alertStyle = .InformationalAlertStyle
-            alert.messageText = NSString(format: NSLocalizedString("Are you sure you want to archive the deck %@ ?", comment: ""), deck.name!) as String
             alert.addButtonWithTitle(NSLocalizedString("OK", comment: ""))
             alert.addButtonWithTitle(NSLocalizedString("Cancel", comment: ""))
+            
+            if deck.isArchived ?? false {
+                alert.messageText = NSString(format: NSLocalizedString("Are you sure you want to unarchive the deck %@ ?", comment: ""), deck.name!) as String
+            } else {
+                alert.messageText = NSString(format: NSLocalizedString("Are you sure you want to archive the deck %@ ?", comment: ""), deck.name!) as String
+            }
             alert.beginSheetModalForWindow(self.window!,
                                            completionHandler: { (returnCode) in
                                             if returnCode == NSAlertFirstButtonReturn {
-                                                deck.isArchived = true
+                                                deck.isArchived = !(deck.isArchived ?? false)
                                                 Settings.instance.activeDeck = nil
                                                 self.refreshDecks()
                                                 Decks.instance.save()

--- a/HSTracker/UIs/DeckManager/DeckManager.swift
+++ b/HSTracker/UIs/DeckManager/DeckManager.swift
@@ -101,9 +101,11 @@ class DeckManager: NSWindowController {
 
     func filteredDecks() -> [Deck] {
         if let currentClass = currentClass {
-            return decks.filter({ $0.playerClass == currentClass }).sort { $0.name < $1.name }
+            return decks.filter({ $0.playerClass == currentClass && $0.isArchived != true }).sort { $0.name < $1.name }
+        } else if showArchivedDecks {
+            return decks.filter({ $0.isArchived == true }).sort { $0.name < $1.name }
         } else {
-            return decks.sort { $0.name < $1.name }
+            return decks.filter({ $0.isArchived != true }).sort { $0.name < $1.name }
         }
     }
 
@@ -182,7 +184,7 @@ class DeckManager: NSWindowController {
         switch item.itemIdentifier {
         case "add", "donate", "twitter", "hearthstats":
             return true
-        case "edit", "use", "delete", "rename":
+        case "edit", "use", "delete", "rename", "archive":
             return currentDeck != nil
         default:
             return false
@@ -299,6 +301,25 @@ class DeckManager: NSWindowController {
                                            completionHandler: { (returnCode) in
                                             if returnCode == NSAlertFirstButtonReturn {
                                                 self._deleteDeck(deck)
+                                            }
+            })
+        }
+    }
+    
+    @IBAction func archiveDeck(sender: AnyObject) {
+        if let deck = currentDeck {
+            let alert = NSAlert()
+            alert.alertStyle = .InformationalAlertStyle
+            alert.messageText = NSString(format: NSLocalizedString("Are you sure you want to archive the deck %@ ?", comment: ""), deck.name!) as String
+            alert.addButtonWithTitle(NSLocalizedString("OK", comment: ""))
+            alert.addButtonWithTitle(NSLocalizedString("Cancel", comment: ""))
+            alert.beginSheetModalForWindow(self.window!,
+                                           completionHandler: { (returnCode) in
+                                            if returnCode == NSAlertFirstButtonReturn {
+                                                deck.isArchived = true
+                                                Settings.instance.activeDeck = nil
+                                                self.refreshDecks()
+                                                Decks.instance.save()
                                             }
             })
         }
@@ -428,7 +449,7 @@ extension DeckManager: NewDeckDelegate {
     func refreshDecks() {
         currentDeck = nil
         decksTable.deselectAll(self)
-        decks = Decks.instance.decks().filter({$0.isActive != showArchivedDecks})
+        decks = Decks.instance.decks()
         classes = [String]()
         for deck in decks {
             if !classes.contains(deck.playerClass) {

--- a/HSTracker/UIs/DeckManager/DeckManager.swift
+++ b/HSTracker/UIs/DeckManager/DeckManager.swift
@@ -102,11 +102,11 @@ class DeckManager: NSWindowController {
 
     func filteredDecks() -> [Deck] {
         if let currentClass = currentClass {
-            return decks.filter({ $0.playerClass == currentClass && $0.isArchived != true }).sort { $0.name < $1.name }
+            return decks.filter({ $0.playerClass == currentClass && $0.isActive == true }).sort { $0.name < $1.name }
         } else if showArchivedDecks {
-            return decks.filter({ $0.isArchived == true }).sort { $0.name < $1.name }
+            return decks.filter({ $0.isActive != true }).sort { $0.name < $1.name }
         } else {
-            return decks.filter({ $0.isArchived != true }).sort { $0.name < $1.name }
+            return decks.filter({ $0.isActive == true }).sort { $0.name < $1.name }
         }
     }
 
@@ -160,7 +160,7 @@ class DeckManager: NSWindowController {
         }
         let clickedRow = sender!.clickedRow!
         currentDeck = filteredDecks()[clickedRow]
-        let labelName = (currentDeck?.isArchived ?? false) ? "Unarchive" : "Archive"
+        let labelName = ((currentDeck?.isActive) == true) ? "Archive" : "Unarchive"
         self.archiveToolBarItem.label = NSLocalizedString(labelName, comment: "")
         deckListTable.reloadData()
         curveView.deck = currentDeck
@@ -316,15 +316,15 @@ class DeckManager: NSWindowController {
             alert.addButtonWithTitle(NSLocalizedString("OK", comment: ""))
             alert.addButtonWithTitle(NSLocalizedString("Cancel", comment: ""))
             
-            if deck.isArchived ?? false {
-                alert.messageText = NSString(format: NSLocalizedString("Are you sure you want to unarchive the deck %@ ?", comment: ""), deck.name!) as String
-            } else {
+            if deck.isActive {
                 alert.messageText = NSString(format: NSLocalizedString("Are you sure you want to archive the deck %@ ?", comment: ""), deck.name!) as String
+            } else {
+                alert.messageText = NSString(format: NSLocalizedString("Are you sure you want to unarchive the deck %@ ?", comment: ""), deck.name!) as String
             }
             alert.beginSheetModalForWindow(self.window!,
                                            completionHandler: { (returnCode) in
                                             if returnCode == NSAlertFirstButtonReturn {
-                                                deck.isArchived = !(deck.isArchived ?? false)
+                                                deck.isActive = !deck.isActive
                                                 Settings.instance.activeDeck = nil
                                                 self.refreshDecks()
                                                 Decks.instance.save()


### PR DESCRIPTION
Here's a simple patch that allows the user to "Archive" a deck. All it does is set a flag on the deck itself so it gets filtered differently than normal decks.

I've set the isArchived to be an optional so it doesn't affect Unboxer. (I'm not sure how unboxer works, but if I did isArchived: Bool = false, Unboxer would fail to initialize it because of the unrecognized key). I figured leaving this as an optional means that the DB doesn't need to be updated with this key per deck. It should "just work"