### PR TITLE
This pull request fixes some bugs when doing class filters

### DIFF
--- a/HSTracker/UIs/DeckManager/DeckManager.swift
+++ b/HSTracker/UIs/DeckManager/DeckManager.swift
@@ -364,7 +364,7 @@ extension DeckManager: NSTableViewDelegate {
         } else {
             let cell = CardBar.factory()
             cell.playerType = .DeckManager
-            cell.card = currentDeck!.sortedCards[row]
+            cell.card = currentDeck?.sortedCards[row]
             return cell
         }
 

--- a/HSTracker/UIs/DeckManager/DeckManager.swift
+++ b/HSTracker/UIs/DeckManager/DeckManager.swift
@@ -144,7 +144,7 @@ class DeckManager: NSWindowController {
 
         showArchivedDecks = sender == archiveButton
 
-        if currentClass == oldCurrentClass {
+        if currentClass == oldCurrentClass && currentDeck == nil {
             currentClass = nil
         }
 
@@ -386,6 +386,7 @@ extension DeckManager: NSTableViewDelegate {
 
     func tableViewSelectionDidChange(notification: NSNotification) {
         let decks = filteredDecks().count
+        guard decks == notification.object?.numberOfRows else { return }
         for i in 0 ..< decks {
             let row = decksTable?.viewAtColumn(0, row: i, makeIfNecessary: false) as? DeckCellView
             row?.selected = decksTable?.selectedRow == -1 || decksTable?.selectedRow == i


### PR DESCRIPTION
Few bugs I found while using the app:

1. If you select a filter (say, Druid), select a deck, filter Druid again, the table view does not get updated
Fix: Check if you have a current deck already selected before setting currentClass to nil. Since refreshDecks() is called whenever we select a filter, it will properly deselect the current selected deck. 

2. If you select a filter with fewer decks than the next filter, the new filter doesn't get applied.
Issue: Since we deselect all decks when selecting a filter, tableViewSelectionDidChange gets called on the old filter as well as the new filter, so there is an issue with row selection.
Fix: Make sure in tableViewSelectionDidChange that we are modifying the new filter and not the old

3. I was hitting some crashes when quickly selecting decks and switching filters, so currentDeck could be nil
Fix: (I think). Don't force unwrap currentDeck. 