### PR TITLE
Don't reset player id when in a game and swapping decks

### DIFF
--- a/HSTracker/Logging/Game.swift
+++ b/HSTracker/Logging/Game.swift
@@ -201,7 +201,7 @@ class Game {
 
     func setActiveDeck(deck: Deck) {
         self.activeDeck = deck
-        player.reset()
+        player.reset(self.gameEnded ? true : false)
         updatePlayerTracker(true)
     }
 

--- a/HSTracker/Logging/Player.swift
+++ b/HSTracker/Logging/Player.swift
@@ -129,12 +129,8 @@ final class Player {
         isLocalPlayer = local
         reset()
     }
-
-    func reset() {
-        self.reset(true)
-    }
     
-    func reset(resetID: Bool) {
+    func reset(resetID: Bool = true) {
         if resetID { id = -1 }
         name = ""
         playerClass = nil

--- a/HSTracker/Logging/Player.swift
+++ b/HSTracker/Logging/Player.swift
@@ -131,7 +131,11 @@ final class Player {
     }
 
     func reset() {
-        id = -1
+        self.reset(true)
+    }
+    
+    func reset(resetID: Bool) {
+        if resetID { id = -1 }
         name = ""
         playerClass = nil
         goingFirst = false


### PR DESCRIPTION
Don't reset player ID if you're in a game and you set a deck.

This fixes the issue here:
https://github.com/bmichotte/HSTracker/issues/459