### PR TITLE
Fix for bug 313

### DIFF
--- a/HSTracker/Logging/Game.swift
+++ b/HSTracker/Logging/Game.swift
@@ -1053,6 +1053,7 @@ class Game {
             if show {
                 if let opponentSecrets = self.opponentSecrets {
                     self.secretTracker?.setSecrets(opponentSecrets)
+                    self.secretTracker?.window?.orderOut(self)
                     self.secretTracker?.showWindow(self)
                 }
             } else {
@@ -1081,6 +1082,7 @@ class Game {
                         hud.setEntity(entity)
                         let frame = SizeHelper.opponentCardHudFrame(i, cardCount: count)
                         hud.window?.setFrame(frame, display: true)
+                        hud.window?.orderOut(self)
                         hud.showWindow(self)
                     } else {
                         hud.window?.orderOut(self)
@@ -1097,6 +1099,7 @@ class Game {
         if settings.playerBoardDamage {
             dispatch_async(dispatch_get_main_queue()) {
                 if !self.gameEnded {
+                    self.playerBoardDamage?.window?.orderOut(self)
                     self.playerBoardDamage?.showWindow(self)
                     self.playerBoardDamage?.update(board.player.damage)
                 } else {
@@ -1110,6 +1113,7 @@ class Game {
         if settings.opponentBoardDamage {
             dispatch_async(dispatch_get_main_queue()) {
                 if !self.gameEnded {
+                    self.opponentBoardDamage?.window?.orderOut(self)
                     self.opponentBoardDamage?.showWindow(self)
                     self.opponentBoardDamage?.update(board.opponent.damage)
                 } else {
@@ -1200,6 +1204,8 @@ class Game {
         }
         if let tracker = self.timerHud {
             moveWindow(tracker, active: active, frame: SizeHelper.timerHudFrame())
+            tracker.window?.orderOut(self)
+            tracker.showWindow(self)
         }
 
         updateCardHuds()
@@ -1207,11 +1213,13 @@ class Game {
             moveWindow(playerBoardDamage,
                        active: active,
                        frame: SizeHelper.playerBoardDamageFrame())
+            updateBoardAttack()
         }
         if let opponentBoardDamage = opponentBoardDamage {
             moveWindow(opponentBoardDamage,
                        active: active,
                        frame: SizeHelper.opponentBoardDamageFrame())
+            updateBoardAttack()
         }
     }
 


### PR DESCRIPTION
**The issue**
Bug #313 (and many duplicates) reported that the board damage, timer, and card huds did not follow the HS window when it was moved to a new virtual desktop ("space") on the same physical monitor. After some investigation, I found that the huds stayed on the old space, and moved around to follow the HS window's position in the new space. Thus, all that they were missing was information about which space they should be on.

**The fix**
It's not clear how to ask for the space of a window or how to move it. But, if we call hud.window.orderOut(), the hud loses its assigned space and becomes assigned to no space. Then, if we call hud.showWindow(), the hud is assigned to the current space. Thus, the solution is to call this pair of functions when the HS window is activated. (Because the HS window can only be activated is the current space is the space containing the HS window.)

Specifically, I added the orderOut call in places where showWindow was already being called due to activation of the HS window. 

**A side benefit**
The board damage huds now update when HS is activated, so the user sees less time lag between turning them on/off and the huds appearing/disappearing. 

I also tested this PR with @jonnguy's PR #496, and it is compatible (seems to be completely orthogonal). @jonnguy raised a concern about memory usage; I tested and did not see any memory growth due to this PR.
