### PR TITLE
Check if images are corrupt on launch and redownload

### DIFF
--- a/HSTracker/Database/ImageDownloader.swift
+++ b/HSTracker/Database/ImageDownloader.swift
@@ -54,7 +54,9 @@ final class ImageDownloader {
             for image in images {
                 let path = "\(destination)/HSTracker/cards/\(image).png"
                 if NSFileManager.defaultManager().fileExistsAtPath(path) {
-                    images.remove(image)
+                    if NSImage(contentsOfFile: path) != nil {
+                        images.remove(image)
+                    }
                 }
             }
 


### PR DESCRIPTION
On launch, we check if any card images are missing and mark them for download. This PR also checks that the image can be loaded, and marks corrupt images for download. This appears to add less than 1 second of overhead on launch.

Hopefully, this will prevent future issues like #518.