### PR TITLE
Three improvements to rank detection

### DIFF
--- a/HSTracker.xcodeproj/project.pbxproj
+++ b/HSTracker.xcodeproj/project.pbxproj
@@ -1803,6 +1803,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_CFLAGS = "$(inherited)";
+				"OTHER_CODE_SIGN_FLAGS[sdk=*]" = "--deep";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "-DDEBUG $(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = be.michotte.HSTracker;
@@ -1828,6 +1829,7 @@
 				INFOPLIST_FILE = HSTracker/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				"OTHER_CODE_SIGN_FLAGS[sdk=*]" = "--deep";
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = be.michotte.HSTracker;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/HSTracker/Logging/Game.swift
+++ b/HSTracker/Logging/Game.swift
@@ -267,8 +267,8 @@ class Game {
                     self.playerRanks.append(playerRank)
                     self.opponentRanks.append(opponentRank)
                     
-                    // check if player rank is in range "opponent rank - 1 -> opponent rank + 1)
-                    if (opponentRank - 1) ... (opponentRank + 1) ~= playerRank {
+                    // check if player rank is in range "opponent rank - 3 -> opponent rank + 3)
+                    if (opponentRank - 3) ... (opponentRank + 3) ~= playerRank {
                         // we can imagine we are on ranked games
                         self.currentGameMode = .Ranked
                     }

--- a/HSTracker/Utility/ImageUtilities.swift
+++ b/HSTracker/Utility/ImageUtilities.swift
@@ -15,9 +15,9 @@ struct ImageUtilities {
         if let image = hearthstoneWindow.screenshot() {
             let cropped = cropRect(image,
                                    rect: NSRect(x: 0,
-                                    y: NSHeight(hearthstoneWindow.frame) - (image.size.height / 3),
-                                    width: image.size.width / 5,
-                                    height: image.size.height / 3))
+                                    y: NSHeight(hearthstoneWindow.frame) - (image.size.height / 5),
+                                    width: image.size.width / 10,
+                                    height: image.size.height / 5))
             return cropped
         }
         return nil
@@ -28,8 +28,8 @@ struct ImageUtilities {
         if let image = hearthstoneWindow.screenshot() {
             let cropped = cropRect(image,
                                    rect: NSRect(x: 0, y: 0,
-                                    width: image.size.width / 5,
-                                    height: image.size.height / 3))
+                                    width: image.size.width / 10,
+                                    height: image.size.height / 5))
             return cropped
         }
         return nil

--- a/HSTracker/Utility/RankDetection/CVRankDetection.swift
+++ b/HSTracker/Utility/RankDetection/CVRankDetection.swift
@@ -44,13 +44,20 @@ class CVRankDetection {
             
             data.writeToFile(tempfile, atomically: true)
             let rank = detector.detectRank(tempfile)
-            Log.info?.message("detected rank for \(player) : \(rank)")
+            
             do {
                 try NSFileManager.defaultManager().removeItemAtURL(fullURL!)
             } catch {
                 Log.info?.message("Failed to remove temp")
             }
-            return Int(rank)
+            
+            if (rank != -1) {
+                Log.info?.message("detected rank for \(player) : \(rank)")
+                return Int(rank)
+            } else {
+                Log.info?.message("Found no rank for \(player)")
+                return nil
+            }
         }
         return nil
     }

--- a/HSTracker/Utility/RankDetection/CVRankDetector.cpp
+++ b/HSTracker/Utility/RankDetection/CVRankDetector.cpp
@@ -83,5 +83,10 @@ int CVRankDetector::detectRank(std::string tempfile)
             best_rank = test_rank;
         }
     }
-    return best_rank;
+
+    if (best_match > nmatches_threshold) {
+        return best_rank;
+    } else {
+        return -1;
+    }
 }

--- a/HSTracker/Utility/RankDetection/CVRankDetector.hpp
+++ b/HSTracker/Utility/RankDetection/CVRankDetector.hpp
@@ -23,6 +23,7 @@ public:
     
 private:
     const double ratio_test_ratio = 0.6;
+    const int nmatches_threshold  = 10;
     
     std::vector<cv::Mat> descriptorsForRank;
     cv::Ptr<cv::Feature2D> detector;


### PR DESCRIPTION
1. Rank detection now returns "nil" when confidence is below a threshold (suggested by @bmichotte). This allows us to determine whether a game is "Casual" or "Ranked" based on whether we can find ranks in the window.

2. Tightened cropping window around rank icons. This should improve accuracy when the game window is very small. This will also improve performance.

3. Increased the allowed difference between player and opponent rank for a game to still be categorized as "Ranked". This is because rank gaps can be large at the beginning of the season or in Wild mode.

These improvements, coupled to the previous rank detection improvements should (hopefully) close a number of issues, including #514, #487, #442, #434 (partially), #415, and #406. 


