### PR TITLE
Cleanup stats

### DIFF
--- a/HSTracker/Base.lproj/Localizable.strings
+++ b/HSTracker/Base.lproj/Localizable.strings
@@ -111,3 +111,14 @@
 "games" = "Games";
 "ascending" = "Ascending";
 "descending" = "Descending";
+
+/* game modes */
+"mode_all"       = "All";
+"mode_ranked"    = "Ranked";
+"mode_casual"    = "Casual";
+"mode_arena"     = "Arena";
+"mode_brawl"     = "Tavern Brawl";
+"mode_friendly"  = "Friendly";
+"mode_practice"  = "Practice/Adventure";
+"mode_spectator" = "Spectator";
+"mode_none"      = "None";

--- a/HSTracker/Database/Models/Deck.swift
+++ b/HSTracker/Database/Models/Deck.swift
@@ -165,31 +165,7 @@ final class Deck: Unboxable, WrapCustomizable, Hashable, CustomStringConvertible
     func addStatistic(statistic: Statistic) {
         statistics.append(statistic)
     }
-
-    func displayStats() -> String {
-        let totalGames = statistics.count
-        if totalGames == 0 {
-            return "0 - 0"
-        }
-
-        return "\(wins()) - \(totalGames - wins()) (\(winPercentage())%)"
-    }
     
-    func wins() -> Int {
-        return statistics.filter { $0.gameResult == .Win }.count
-    }
-    
-    func losses() -> Int {
-        return statistics.filter { $0.gameResult == .Loss }.count
-    }
-    
-    func winPercentage() -> Int {
-        let totalGames = statistics.count
-        if totalGames == 0 {
-            return 0
-        }
-        return Int(round(Double(wins()) / Double(totalGames) * 100))
-    }
 
     func standardViable() -> Bool {
         return !isArena && !_cards.any({ $0.set != nil && CardSet.wildSets().contains($0.set!) })

--- a/HSTracker/Logging/Enums/GameMode.swift
+++ b/HSTracker/Logging/Enums/GameMode.swift
@@ -26,4 +26,18 @@ enum GameMode: Int, UnboxableEnum, WrappableEnum {
     static func unboxFallbackValue() -> GameMode {
         return .None
     }
+    
+    var userFacingName: String {
+        switch self {
+        case .All:       return NSLocalizedString("mode_all", comment: "")
+        case .Ranked:    return NSLocalizedString("mode_ranked", comment: "")
+        case .Casual:    return NSLocalizedString("mode_casual", comment: "")
+        case .Arena:     return NSLocalizedString("mode_arena", comment: "")
+        case .Brawl:     return NSLocalizedString("mode_brawl", comment: "")
+        case .Friendly:  return NSLocalizedString("mode_friendly", comment: "")
+        case .Practice:  return NSLocalizedString("mode_practice", comment: "")
+        case .Spectator: return NSLocalizedString("mode_spectator", comment: "")
+        case .None:      return NSLocalizedString("mode_none", comment: "")
+        }
+    }
 }

--- a/HSTracker/Statistics/StatsHelper.swift
+++ b/HSTracker/Statistics/StatsHelper.swift
@@ -94,10 +94,12 @@ class StatsHelper {
         if againstClass.lowercaseString != "all" {
             stats = deck.statistics.filter({$0.opponentClass == againstClass.lowercaseString})
         }
+        
+        let rankedStats = stats.filter({$0.playerMode == GameMode.Ranked})
+        let wins   = rankedStats.filter({$0.gameResult == GameResult.Win}).count
+        let losses = rankedStats.filter({$0.gameResult == GameResult.Loss}).count
+        let draws  = rankedStats.filter({$0.gameResult == GameResult.Draw}).count
 
-        let wins = stats.filter({$0.gameResult == GameResult.Win}).count
-        let losses = stats.filter({$0.gameResult == GameResult.Loss}).count
-        let draws = stats.filter({$0.gameResult == GameResult.Draw}).count
         return StatsDeckRecord(wins: wins, losses: losses, draws: draws, total: wins+losses+draws)
     }
 

--- a/HSTracker/Statistics/StatsHelper.swift
+++ b/HSTracker/Statistics/StatsHelper.swift
@@ -66,7 +66,17 @@ class StatsHelper {
 
         return tableData
     }
-
+    
+    static func getDeckManagerRecordLabel(deck: Deck) -> String {
+        let record = getDeckRecord(deck)
+        
+        let totalGames = record.total
+        if totalGames == 0 {
+            return "0 - 0"
+        }
+        
+        return "\(record.wins) - \(record.losses) (\(getDeckWinRateString(record)))"
+    }
     static func getDeckRecordString(record: StatsDeckRecord) -> String {
         return "\(record.wins)-\(record.losses)"
     }

--- a/HSTracker/Statistics/StatsHelper.swift
+++ b/HSTracker/Statistics/StatsHelper.swift
@@ -22,6 +22,13 @@ class StatsTableRow: NSObject { // Class instead of struct so we can use sortUsi
     var confidenceWindow = 1.0
 }
 
+struct StatsDeckRecord {
+    var wins   = 0
+    var losses = 0
+    var draws  = 0
+    var total  = 0
+}
+
 class StatsHelper {
     static let playerClassList = [
         "druid", "hunter", "mage", "paladin", "priest",
@@ -40,16 +47,16 @@ class StatsHelper {
                 dataRow.classIcon = againstClass
             }
             dataRow.opponentClassName = NSLocalizedString(againstClass, comment: "")
-            dataRow.record            = getDeckRecordString(deck, againstClass: againstClass)
-            dataRow.winRate           = getDeckWinRateString(deck, againstClass: againstClass)
-            dataRow.winRateNumber     = getDeckWinRate(deck, againstClass: againstClass)
-            dataRow.totalGames        = getDeckRecord(deck, againstClass: againstClass).total
-            dataRow.confidenceInterval = getDeckConfidenceString(deck,
-                                                                 againstClass: againstClass,
+            
+            let record = getDeckRecord(deck, againstClass: againstClass)
+            dataRow.record            = getDeckRecordString(record)
+            dataRow.winRate           = getDeckWinRateString(record)
+            dataRow.winRateNumber     = getDeckWinRate(record)
+            dataRow.totalGames        = record.total
+            dataRow.confidenceInterval = getDeckConfidenceString(record,
                                                                  confidence: 0.9)
-            let stats = getDeckRecord(deck, againstClass: againstClass)
-            let interval = binomialProportionCondifenceInterval(stats.wins,
-                                                                losses: stats.losses,
+            let interval = binomialProportionCondifenceInterval(record.wins,
+                                                                losses: record.losses,
                                                                 confidence: 0.9)
             dataRow.confidenceWindow   = interval.upper - interval.lower
 
@@ -59,16 +66,11 @@ class StatsHelper {
         return tableData
     }
 
-    static func getDeckRecordString(deck: Deck, againstClass: String = "all") -> String {
-        let record = getDeckRecord(deck, againstClass: againstClass)
-        let recordString: String = "\(record.wins)-\(record.losses)"
-
-        return recordString
+    static func getDeckRecordString(record: StatsDeckRecord) -> String {
+        return "\(record.wins)-\(record.losses)"
     }
 
-    static func getDeckWinRate(deck: Deck, againstClass: String = "all") -> Double {
-        let record = getDeckRecord(deck, againstClass: againstClass)
-
+    static func getDeckWinRate(record: StatsDeckRecord) -> Double {
         let totalGames = record.wins + record.losses
         var winRate = -1.0
         if totalGames > 0 {
@@ -77,9 +79,9 @@ class StatsHelper {
         return winRate
     }
 
-    static func getDeckWinRateString(deck: Deck, againstClass: String = "all") -> String {
+    static func getDeckWinRateString(record: StatsDeckRecord) -> String {
         var winRateString = "N/A"
-        let winRate = getDeckWinRate(deck, againstClass: againstClass)
+        let winRate = getDeckWinRate(record)
         if winRate >= 0.0 {
             let winPercent = Int(round(winRate * 100))
             winRateString = String(winPercent) + "%"
@@ -87,8 +89,7 @@ class StatsHelper {
         return winRateString
     }
 
-    static func getDeckRecord(deck: Deck, againstClass: String = "all")
-        -> (wins: Int, losses: Int, draws: Int, total: Int) {
+    static func getDeckRecord(deck: Deck, againstClass: String = "all") -> StatsDeckRecord {
         var stats = deck.statistics
         if againstClass.lowercaseString != "all" {
             stats = deck.statistics.filter({$0.opponentClass == againstClass.lowercaseString})
@@ -97,15 +98,13 @@ class StatsHelper {
         let wins = stats.filter({$0.gameResult == GameResult.Win}).count
         let losses = stats.filter({$0.gameResult == GameResult.Loss}).count
         let draws = stats.filter({$0.gameResult == GameResult.Draw}).count
-
-        return (wins, losses, draws, wins+losses+draws)
+        return StatsDeckRecord(wins: wins, losses: losses, draws: draws, total: wins+losses+draws)
     }
 
-    static func getDeckConfidenceString(deck: Deck, againstClass: String = "all",
+    static func getDeckConfidenceString(record: StatsDeckRecord,
                                         confidence: Double = 0.9) -> String {
-        let stats = getDeckRecord(deck, againstClass: againstClass)
-        let interval = binomialProportionCondifenceInterval(stats.wins,
-                                                            losses: stats.losses,
+        let interval = binomialProportionCondifenceInterval(record.wins,
+                                                            losses: record.losses,
                                                             confidence: confidence)
         let intLower = Int(round(interval.lower*100))
         let intUpper = Int(round(interval.upper*100))

--- a/HSTracker/Statistics/StatsHelper.swift
+++ b/HSTracker/Statistics/StatsHelper.swift
@@ -46,7 +46,8 @@ class StatsHelper {
             } else {
                 dataRow.classIcon = againstClass
             }
-            dataRow.opponentClassName = NSLocalizedString(againstClass, comment: "")
+            dataRow.opponentClassName =
+                NSLocalizedString(againstClass, comment: "").capitalizedString
             
             let record = getDeckRecord(deck, againstClass: againstClass)
             dataRow.record            = getDeckRecordString(record)

--- a/HSTracker/Statistics/StatsHelper.swift
+++ b/HSTracker/Statistics/StatsHelper.swift
@@ -106,10 +106,11 @@ class StatsHelper {
             stats = deck.statistics.filter({$0.opponentClass == againstClass.lowercaseString})
         }
         
-        let rankedStats = stats.filter({$0.playerMode == GameMode.Ranked})
-        let wins   = rankedStats.filter({$0.gameResult == GameResult.Win}).count
-        let losses = rankedStats.filter({$0.gameResult == GameResult.Loss}).count
-        let draws  = rankedStats.filter({$0.gameResult == GameResult.Draw}).count
+        let rankedStats = stats.filter({$0.playerMode == .Ranked})
+        
+        let wins   = rankedStats.filter({$0.gameResult == .Win}).count
+        let losses = rankedStats.filter({$0.gameResult == .Loss}).count
+        let draws  = rankedStats.filter({$0.gameResult == .Draw}).count
 
         return StatsDeckRecord(wins: wins, losses: losses, draws: draws, total: wins+losses+draws)
     }

--- a/HSTracker/Statistics/StatsHelper.swift
+++ b/HSTracker/Statistics/StatsHelper.swift
@@ -35,7 +35,7 @@ class StatsHelper {
         "rogue", "shaman", "warlock", "warrior"
         ].sort { NSLocalizedString($0, comment: "") < NSLocalizedString($1, comment: "") }
 
-    static func getStatsUITableData(deck: Deck) -> [StatsTableRow] {
+    static func getStatsUITableData(deck: Deck, mode: GameMode = .Ranked) -> [StatsTableRow] {
         var tableData = [StatsTableRow]()
 
         for againstClass in ["all"] + StatsHelper.playerClassList {
@@ -49,7 +49,7 @@ class StatsHelper {
             dataRow.opponentClassName =
                 NSLocalizedString(againstClass, comment: "").capitalizedString
             
-            let record = getDeckRecord(deck, againstClass: againstClass)
+            let record = getDeckRecord(deck, againstClass: againstClass, mode: mode)
             dataRow.record            = getDeckRecordString(record)
             dataRow.winRate           = getDeckWinRateString(record)
             dataRow.winRateNumber     = getDeckWinRate(record)
@@ -100,13 +100,19 @@ class StatsHelper {
         return winRateString
     }
 
-    static func getDeckRecord(deck: Deck, againstClass: String = "all") -> StatsDeckRecord {
+    static func getDeckRecord(deck: Deck, againstClass: String = "all", mode: GameMode = .Ranked)
+        -> StatsDeckRecord {
         var stats = deck.statistics
         if againstClass.lowercaseString != "all" {
             stats = deck.statistics.filter({$0.opponentClass == againstClass.lowercaseString})
         }
         
-        let rankedStats = stats.filter({$0.playerMode == .Ranked})
+        var rankedStats: [Statistic]
+        if mode == .All {
+            rankedStats = stats
+        } else {
+            rankedStats = stats.filter({$0.playerMode == mode})
+        }
         
         let wins   = rankedStats.filter({$0.gameResult == .Win}).count
         let losses = rankedStats.filter({$0.gameResult == .Loss}).count

--- a/HSTracker/UIs/DeckManager/DeckManager.swift
+++ b/HSTracker/UIs/DeckManager/DeckManager.swift
@@ -119,13 +119,21 @@ class DeckManager: NSWindowController {
         case "creation date":
             sortedDeck = filteredDeck.sort({ $0.creationDate! < $1.creationDate! })
         case "win percentage":
-            sortedDeck = filteredDeck.sort({ $0.winPercentage() < $1.winPercentage() })
+            sortedDeck = filteredDeck.sort({
+                  StatsHelper.getDeckWinRate(StatsHelper.getDeckRecord($0)) <
+                  StatsHelper.getDeckWinRate(StatsHelper.getDeckRecord($1)) })
         case "wins":
-            sortedDeck = filteredDeck.sort({ $0.wins() < $1.wins() })
+            sortedDeck = filteredDeck.sort({
+                  StatsHelper.getDeckRecord($0).wins <
+                  StatsHelper.getDeckRecord($1).wins })
         case "losses":
-            sortedDeck = filteredDeck.sort({ $0.losses() < $1.losses() })
+            sortedDeck = filteredDeck.sort({
+                  StatsHelper.getDeckRecord($0).losses <
+                  StatsHelper.getDeckRecord($1).losses })
         case "games played":
-            sortedDeck = filteredDeck.sort({ $0.statistics.count < $1.statistics.count })
+            sortedDeck = filteredDeck.sort({
+                  StatsHelper.getDeckRecord($0).total <
+                  StatsHelper.getDeckRecord($1).total })
         default:
             sortedDeck = filteredDeck
         }
@@ -191,7 +199,7 @@ class DeckManager: NSWindowController {
     func updateStatsLabel() {
         if let currentDeck = self.currentDeck {
             dispatch_async(dispatch_get_main_queue()) {
-                self.statsLabel.stringValue = currentDeck.displayStats()
+                self.statsLabel.stringValue = StatsHelper.getDeckManagerRecordLabel(currentDeck)
                 self.curveView.reload()
             }
         }
@@ -503,6 +511,7 @@ extension DeckManager: NSTableViewDelegate {
                 cell.color = ClassColor.color(deck.playerClass)
                 cell.selected = tableView.selectedRow == -1 || tableView.selectedRow == row
                 
+                let record = StatsHelper.getDeckRecord(deck)
                 switch sortCriteria {
                 case "creation date":
                     let formatter = NSDateFormatter()
@@ -511,16 +520,16 @@ extension DeckManager: NSTableViewDelegate {
                     cell.detailTextLabel.stringValue =
                         "\(formatter.stringFromDate(deck.creationDate!))"
                 case "wins":
-                    cell.detailTextLabel.stringValue = "\(deck.wins()) " +
+                    cell.detailTextLabel.stringValue = "\(record.wins) " +
                         NSLocalizedString("wins", comment: "").lowercaseString
                 case "losses":
-                    cell.detailTextLabel.stringValue = "\(deck.losses()) " +
+                    cell.detailTextLabel.stringValue = "\(record.losses) " +
                         NSLocalizedString("losses", comment: "").lowercaseString
                 case "games played":
-                    cell.detailTextLabel.stringValue = "\(deck.statistics.count) " +
+                    cell.detailTextLabel.stringValue = "\(record.total) " +
                         NSLocalizedString("games", comment: "").lowercaseString
                 default:
-                    cell.detailTextLabel.stringValue = "\(deck.displayStats())"
+                    cell.detailTextLabel.stringValue = StatsHelper.getDeckManagerRecordLabel(deck)
                 }
 
                 return cell

--- a/HSTracker/UIs/StatsManager/Base.lproj/Statistics.xib
+++ b/HSTracker/UIs/StatsManager/Base.lproj/Statistics.xib
@@ -6,6 +6,7 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="Statistics" customModule="HSTracker" customModuleProvider="target">
             <connections>
+                <outlet property="modePicker" destination="hD3-ex-LDp" id="fLP-RX-R9G"/>
                 <outlet property="selectedDeckIcon" destination="ow7-WG-eSm" id="AoD-Eg-bLd"/>
                 <outlet property="selectedDeckName" destination="SSf-yV-UWh" id="n8A-n9-KBI"/>
                 <outlet property="statsTable" destination="ypb-VB-h3e" id="Y3X-Ij-3hX"/>
@@ -17,14 +18,14 @@
         <window title="Deck Statistics" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" oneShot="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="F0z-JX-Cv5">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="196" y="240" width="414" height="321"/>
+            <rect key="contentRect" x="196" y="240" width="414" height="353"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
             <view key="contentView" id="se5-gp-TjO">
-                <rect key="frame" x="0.0" y="0.0" width="414" height="321"/>
+                <rect key="frame" x="0.0" y="0.0" width="414" height="353"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ow7-WG-eSm">
-                        <rect key="frame" x="20" y="286" width="20" height="20"/>
+                        <rect key="frame" x="20" y="318" width="20" height="20"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="20" id="3T9-p8-ALk"/>
                             <constraint firstAttribute="width" constant="20" id="J6r-Tj-GT7"/>
@@ -32,13 +33,24 @@
                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="error" id="Yyc-7X-yak"/>
                     </imageView>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="SSf-yV-UWh">
-                        <rect key="frame" x="42" y="286" width="352" height="19"/>
+                        <rect key="frame" x="42" y="318" width="354" height="19"/>
                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="No deck selected" placeholderString="" id="hZh-Kz-cgX">
                             <font key="font" metaFont="system" size="16"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
+                    <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hD3-ex-LDp">
+                        <rect key="frame" x="17" y="286" width="155" height="26"/>
+                        <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="agE-9B-LnI">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                            <menu key="menu" id="ZNF-vG-MA1"/>
+                        </popUpButtonCell>
+                        <connections>
+                            <action selector="modeSelected:" target="-2" id="Fq3-wi-0QZ"/>
+                        </connections>
+                    </popUpButton>
                     <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pZT-ra-2mp">
                         <rect key="frame" x="20" y="51" width="374" height="225"/>
                         <clipView key="contentView" id="gem-f4-3oN">
@@ -66,7 +78,7 @@
                                             <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                             <prototypeCellViews>
                                                 <tableCellView identifier="StatsClassCellID" id="Wev-DN-mXd">
-                                                    <rect key="frame" x="1" y="1" width="103.5" height="17"/>
+                                                    <rect key="frame" x="1" y="1" width="103" height="17"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <subviews>
                                                         <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="y6q-hl-UTc">
@@ -91,7 +103,7 @@
                                                         <constraint firstItem="gUQ-6p-rvu" firstAttribute="leading" secondItem="y6q-hl-UTc" secondAttribute="trailing" constant="7" id="O6s-aq-wRL"/>
                                                         <constraint firstItem="gUQ-6p-rvu" firstAttribute="centerY" secondItem="Wev-DN-mXd" secondAttribute="centerY" id="QOb-nG-zlZ"/>
                                                         <constraint firstItem="y6q-hl-UTc" firstAttribute="leading" secondItem="Wev-DN-mXd" secondAttribute="leading" constant="3" id="eIM-ZP-lau"/>
-                                                        <constraint firstAttribute="trailing" secondItem="gUQ-6p-rvu" secondAttribute="trailing" constant="3" id="mTg-cj-eRH"/>
+                                                        <constraint firstAttribute="trailing" secondItem="gUQ-6p-rvu" secondAttribute="trailing" constant="2" id="mTg-cj-eRH"/>
                                                     </constraints>
                                                     <connections>
                                                         <outlet property="imageView" destination="y6q-hl-UTc" id="Zcu-GF-Pat"/>
@@ -114,7 +126,7 @@
                                             <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                             <prototypeCellViews>
                                                 <tableCellView identifier="StatsRecordCellID" id="caW-tN-Gx7">
-                                                    <rect key="frame" x="107" y="1" width="74" height="20"/>
+                                                    <rect key="frame" x="106.5" y="1" width="73" height="20"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <subviews>
                                                         <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="bHa-z9-HFd">
@@ -128,7 +140,7 @@
                                                     </subviews>
                                                     <constraints>
                                                         <constraint firstItem="bHa-z9-HFd" firstAttribute="centerY" secondItem="caW-tN-Gx7" secondAttribute="centerY" id="2Et-ix-bGO"/>
-                                                        <constraint firstAttribute="trailing" secondItem="bHa-z9-HFd" secondAttribute="trailing" constant="3" id="UFA-up-60H"/>
+                                                        <constraint firstAttribute="trailing" secondItem="bHa-z9-HFd" secondAttribute="trailing" constant="2" id="UFA-up-60H"/>
                                                         <constraint firstItem="bHa-z9-HFd" firstAttribute="leading" secondItem="caW-tN-Gx7" secondAttribute="leading" constant="3" id="v6Q-Y0-YmN"/>
                                                     </constraints>
                                                     <connections>
@@ -151,7 +163,7 @@
                                             <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                             <prototypeCellViews>
                                                 <tableCellView identifier="StatsWinRateCellID" id="dkG-bZ-czD">
-                                                    <rect key="frame" x="183" y="1" width="80" height="17"/>
+                                                    <rect key="frame" x="182" y="1" width="80" height="17"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <subviews>
                                                         <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Pjq-wz-Gyu">
@@ -188,7 +200,7 @@
                                             <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                             <prototypeCellViews>
                                                 <tableCellView identifier="StatsCICellID" id="1L0-lr-GOr">
-                                                    <rect key="frame" x="266" y="1" width="104" height="17"/>
+                                                    <rect key="frame" x="264.5" y="1" width="104" height="17"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <subviews>
                                                         <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qV0-nt-nkg">
@@ -257,11 +269,11 @@ DQ
                     <constraint firstAttribute="trailing" secondItem="pZT-ra-2mp" secondAttribute="trailing" constant="20" id="ALe-7f-3H7"/>
                     <constraint firstItem="aec-Hd-iZi" firstAttribute="top" secondItem="pZT-ra-2mp" secondAttribute="bottom" constant="10" id="FnR-W6-mAP"/>
                     <constraint firstItem="ow7-WG-eSm" firstAttribute="leading" secondItem="se5-gp-TjO" secondAttribute="leading" constant="20" id="Kmm-fp-wbz"/>
-                    <constraint firstAttribute="trailing" secondItem="SSf-yV-UWh" secondAttribute="trailing" constant="22" id="KpB-Wg-Zuu"/>
+                    <constraint firstAttribute="trailing" secondItem="SSf-yV-UWh" secondAttribute="trailing" constant="20" id="KpB-Wg-Zuu"/>
                     <constraint firstItem="ow7-WG-eSm" firstAttribute="top" secondItem="se5-gp-TjO" secondAttribute="top" constant="15" id="ZDG-jO-xu6"/>
                     <constraint firstAttribute="trailing" secondItem="aec-Hd-iZi" secondAttribute="trailing" constant="20" id="Zqe-0m-ifM"/>
                     <constraint firstItem="xL3-PC-COg" firstAttribute="leading" secondItem="se5-gp-TjO" secondAttribute="leading" constant="20" id="dSa-KK-gWs"/>
-                    <constraint firstItem="pZT-ra-2mp" firstAttribute="top" secondItem="SSf-yV-UWh" secondAttribute="bottom" constant="10" id="mHN-mY-MZM"/>
+                    <constraint firstItem="pZT-ra-2mp" firstAttribute="top" secondItem="SSf-yV-UWh" secondAttribute="bottom" constant="42" id="mHN-mY-MZM"/>
                     <constraint firstItem="SSf-yV-UWh" firstAttribute="top" secondItem="ow7-WG-eSm" secondAttribute="bottom" constant="-19" id="s4X-u7-OD6"/>
                     <constraint firstItem="pZT-ra-2mp" firstAttribute="leading" secondItem="se5-gp-TjO" secondAttribute="leading" constant="20" id="y1G-5v-pa9"/>
                 </constraints>
@@ -269,7 +281,7 @@ DQ
             <connections>
                 <outlet property="delegate" destination="-2" id="0bl-1N-AYu"/>
             </connections>
-            <point key="canvasLocation" x="212" y="385.5"/>
+            <point key="canvasLocation" x="212" y="401.5"/>
         </window>
     </objects>
     <resources>

--- a/HSTracker/UIs/Trackers/Tracker.swift
+++ b/HSTracker/UIs/Trackers/Tracker.swift
@@ -330,7 +330,7 @@ class Tracker: NSWindowController {
         fatigueTracker.hidden = !(settings.fatigueIndicator && player?.fatigue > 0)
 
         if let activeDeck = Game.instance.activeDeck where !recordTracker.hidden {
-            recordTracker.message = activeDeck.displayStats()
+            recordTracker.message = StatsHelper.getDeckManagerRecordLabel(activeDeck)
             recordTracker.needsDisplay = true
         } else {
             recordTracker.hidden = true

--- a/HSTracker/de.lproj/Localizable.strings
+++ b/HSTracker/de.lproj/Localizable.strings
@@ -110,3 +110,14 @@
 "games" = "Spiele";
 "ascending" = "Aufsteigend";
 "descending" = "Absteigend";
+
+/* game modes */
+"mode_all"       = "All";
+"mode_ranked"    = "Ranked";
+"mode_casual"    = "Casual";
+"mode_arena"     = "Arena";
+"mode_brawl"     = "Tavern Brawl";
+"mode_friendly"  = "Friendly";
+"mode_practice"  = "Practice/Adventure";
+"mode_spectator" = "Spectator";
+"mode_none"      = "None";

--- a/HSTracker/es.lproj/Localizable.strings
+++ b/HSTracker/es.lproj/Localizable.strings
@@ -111,3 +111,14 @@
 "games" = "Games";
 "ascending" = "Ascending";
 "descending" = "Descending";
+
+/* game modes */
+"mode_all"       = "All";
+"mode_ranked"    = "Ranked";
+"mode_casual"    = "Casual";
+"mode_arena"     = "Arena";
+"mode_brawl"     = "Tavern Brawl";
+"mode_friendly"  = "Friendly";
+"mode_practice"  = "Practice/Adventure";
+"mode_spectator" = "Spectator";
+"mode_none"      = "None";

--- a/HSTracker/fr.lproj/Localizable.strings
+++ b/HSTracker/fr.lproj/Localizable.strings
@@ -111,3 +111,14 @@
 "games" = "Parties";
 "ascending" = "Montant";
 "descending" = "Descendant";
+
+/* game modes */
+"mode_all"       = "All";
+"mode_ranked"    = "Ranked";
+"mode_casual"    = "Casual";
+"mode_arena"     = "Arena";
+"mode_brawl"     = "Tavern Brawl";
+"mode_friendly"  = "Friendly";
+"mode_practice"  = "Practice/Adventure";
+"mode_spectator" = "Spectator";
+"mode_none"      = "None";

--- a/HSTracker/it.lproj/Localizable.strings
+++ b/HSTracker/it.lproj/Localizable.strings
@@ -111,3 +111,14 @@
 "games" = "Games";
 "ascending" = "Ascending";
 "descending" = "Descending";
+
+/* game modes */
+"mode_all"       = "All";
+"mode_ranked"    = "Ranked";
+"mode_casual"    = "Casual";
+"mode_arena"     = "Arena";
+"mode_brawl"     = "Tavern Brawl";
+"mode_friendly"  = "Friendly";
+"mode_practice"  = "Practice/Adventure";
+"mode_spectator" = "Spectator";
+"mode_none"      = "None";

--- a/HSTracker/pt-BR.lproj/Localizable.strings
+++ b/HSTracker/pt-BR.lproj/Localizable.strings
@@ -111,3 +111,14 @@
 "games" = "Games";
 "ascending" = "Ascending";
 "descending" = "Descending";
+
+/* game modes */
+"mode_all"       = "All";
+"mode_ranked"    = "Ranked";
+"mode_casual"    = "Casual";
+"mode_arena"     = "Arena";
+"mode_brawl"     = "Tavern Brawl";
+"mode_friendly"  = "Friendly";
+"mode_practice"  = "Practice/Adventure";
+"mode_spectator" = "Spectator";
+"mode_none"      = "None";

--- a/HSTracker/zh-Hans.lproj/Localizable.strings
+++ b/HSTracker/zh-Hans.lproj/Localizable.strings
@@ -110,3 +110,14 @@
 "games" = "游戏";
 "ascending" = "升序";
 "descending" = "降序";
+
+/* game modes */
+"mode_all"       = "All";
+"mode_ranked"    = "Ranked";
+"mode_casual"    = "Casual";
+"mode_arena"     = "Arena";
+"mode_brawl"     = "Tavern Brawl";
+"mode_friendly"  = "Friendly";
+"mode_practice"  = "Practice/Adventure";
+"mode_spectator" = "Spectator";
+"mode_none"      = "None";


### PR DESCRIPTION
Four fixes to how stats are computed and displayed:

1. Only ranked games are shown
2. Fixed capitalization of class names in stats window
3. Cleaned up internals of StatsHelper
4. DeckManager and record tracker get stats from StatsHelper instead of Deck (put all stat handling in one place)